### PR TITLE
Update restore to support variables

### DIFF
--- a/src/restore.ts
+++ b/src/restore.ts
@@ -1,6 +1,6 @@
 import { onMount } from 'svelte';
-import { DocumentNode } from 'graphql';
-import ApolloClient from 'apollo-client';
+import ApolloClient, { OperationVariables } from 'apollo-client';
+import { DataProxy } from 'apollo-cache';
 
 export type Restoring<TCache> =
   | WeakSet<ApolloClient<TCache>>
@@ -9,17 +9,16 @@ export type Restoring<TCache> =
 export const restoring: Restoring<any> =
   typeof WeakSet !== 'undefined' ? new WeakSet() : new Set();
 
-export default function restore<TCache = any, TData = any>(
+export default function restore<TCache = any, TData = any, TVariables = OperationVariables>(
   client: ApolloClient<TCache>,
-  query: DocumentNode,
-  data: TData
+  options: DataProxy.WriteQueryOptions<TData, TVariables>,
 ): void {
   restoring.add(client);
   afterHydrate(() => {
     restoring.delete(client);
   });
 
-  client.writeQuery({ query, data });
+  client.writeQuery(options);
 }
 
 function afterHydrate(callback: () => void): void {

--- a/tests/restore.test.ts
+++ b/tests/restore.test.ts
@@ -1,5 +1,30 @@
 import { restore } from '../src';
+import { restoring } from '../src/restore';
+import { MockClient } from './helpers';
 
 it('should export restore', () => {
   expect(typeof restore).toBe('function');
 });
+
+it('should add client to restoring set', () => {
+  const client = new MockClient();
+  const options = { query: {}, data: {} };
+  restore(client, options);
+
+  expect(restoring.has(client)).toEqual(true);
+})
+
+it('should call client writeQuery', () => {
+  const client = new MockClient({
+    writeQuery() {}
+  });
+  const options = { query: {}, data: {} };
+  restore(client, options);
+
+  expect(mock(client.writeQuery)).toBeCalled();
+  expect(mock(client.writeQuery)).lastCalledWith(options);
+});
+
+function mock(value: any): any {
+  return value;
+}


### PR DESCRIPTION
This PR updates the `restore` function to support all values that can be passed to `writeQuery`.

```js
restore(client, { query: GET_BOOKS, variables: { bookId: 42 }, data: cache.data });
restore(client, { query: GET_BOOKS, data: cache.data });
```

This is a breaking change to the `restore` API, but I believe it's the best approach. If you agree, I'm happy to update the documentation.