### PR TITLE
Add toPromise function to query

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -26,6 +26,7 @@ export interface QueryStore<TData = any> {
   startPolling: ObservableQuery['startPolling'];
   stopPolling: ObservableQuery['stopPolling'];
   subscribeToMore: ObservableQuery['subscribeToMore'];
+  toPromise: () => Promise<ApolloQueryResult<TData>>;
 }
 
 export default function query<TData = any, TCache = any, TVariables = any>(
@@ -80,6 +81,8 @@ export default function query<TData = any, TCache = any, TVariables = any>(
     }
   );
 
+  const toPromise: () => Promise<ApolloQueryResult<TData>> = () => new Promise((resolve, reject) => observable_query.subscribe(resolve, reject))
+
   return {
     subscribe,
     refetch: variables => {
@@ -95,6 +98,7 @@ export default function query<TData = any, TCache = any, TVariables = any>(
     updateQuery: map => observable_query.updateQuery(map),
     startPolling: interval => observable_query.startPolling(interval),
     stopPolling: () => observable_query.stopPolling(),
-    subscribeToMore: options => observable_query.subscribeToMore(options)
+    subscribeToMore: options => observable_query.subscribeToMore(options),
+    toPromise
   };
 }


### PR DESCRIPTION
## What's the problem?
Handling asynchronous calls using `{#await promise}` blocks is really neat in svelte but unfortunately you can't easily use await when handling the data within your `<script>` tags or in other contexts.

## Solution
Implement a `toPromise` function for queries that allows you to turn your query observable into a promise in order to use `async`/`await`. 

Turns this:
```javascript
query(
    client, 
    { 
      query: THINGS,
    }
  ).subscribe(
    async (res) => {
      const { data } = await res
      // ...
    },
    error => {
      // ...
    }
  )
```

Into this:
```javascript
try {
  const { data } = query(
    client, 
    { 
      query: THINGS,
    }
  ).toPromise()
} catch(error) {
  //...
}
```

## Outstanding issues

- How should unsubscribing be handled?
- Documentation