### PR TITLE
Make restore work as it should

### DIFF
--- a/example/src/Books.svelte
+++ b/example/src/Books.svelte
@@ -12,7 +12,7 @@
   import { getClient, restore, query } from '../../';
   
   export let cache;
-  restore(client, BOOKS, cache.data);
+  restore(client, { query: BOOKS, data: cache.data });
 
   const books = query(client, { query: BOOKS });
 </script>


### PR DESCRIPTION
Disclaimer: I have very little knowledge of svelte or Apollo.

However, the restore.ts uses the `writeQuery` method to store the query, and the arguments passed to it don't match the API signature.

https://www.apollographql.com/docs/react/v2.4/api/apollo-client/#ApolloClient.writeQuery