### PR TITLE
fix ssr data restore

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,14 +20,13 @@
 		"typecheck": "tsc --noEmit",
 		"format": "prettier --write \"src/**/*.ts\""
 	},
-	"dependencies": {},
 	"peerDependencies": {
-		"@apollo/client": "^3.0.0",
+		"@apollo/client": "^3.2.0",
 		"graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0",
 		"svelte": "^3.0.0"
 	},
 	"devDependencies": {
-		"@apollo/client": "^3.1.1",
+		"@apollo/client": "^3.2.0",
 		"@rollup/plugin-typescript": "^5.0.2",
 		"@types/jest": "^26.0.8",
 		"graphql": "^14.7.0",
@@ -39,7 +38,7 @@
 		"rollup-plugin-filesize": "^9.0.2",
 		"svelte": "^3.24.0",
 		"ts-jest": "^26.1.4",
-		"typescript": "^3.9.7"
+		"typescript": "^4.0.2"
 	},
 	"jest": {
 		"testEnvironment": "node",

--- a/src/context.ts
+++ b/src/context.ts
@@ -4,7 +4,7 @@ import { getContext, setContext } from "svelte";
 const CLIENT = typeof Symbol !== "undefined" ? Symbol("client") : "@@client";
 
 export function getClient<TCache = any>(): ApolloClient<TCache> {
-	const client = getContext(CLIENT);
+	const client = getContext<ApolloClient<TCache> | undefined>(CLIENT);
 
 	if (!client) {
 		throw new Error(

--- a/src/observable.ts
+++ b/src/observable.ts
@@ -110,7 +110,7 @@ export type ReadableQuery<TData> = ReadableResult<TData> &
 	ObservableQueryExtensions;
 
 export function observableQueryToReadable<TData = any>(
-	query: ObservableQuery<TData>,
+	query: ObservableQuery<TData, any>,
 	initialValue?: Result<TData>
 ): ReadableQuery<TData> {
 	const store = observableToReadable(query, initialValue) as ReadableQuery<

--- a/src/query.ts
+++ b/src/query.ts
@@ -12,17 +12,21 @@ export function query<TData = any, TVariables = any>(
 	const queryOptions = { ...options, query };
 
 	// If client is restoring (e.g. from SSR), attempt synchronous readQuery first
-	let initialValue: ApolloQueryResult<TData> | undefined;
+	let initialValue: Omit<ApolloQueryResult<TData>, 'networkStatus'> | undefined;
+
 	if (restoring.has(client)) {
 		try {
 			// undefined = skip initial value (not in cache)
-			initialValue = client.readQuery(queryOptions) || undefined;
+			const data = client.readQuery(queryOptions)
+
+			initialValue = data && { data, error: undefined, loading: false } || undefined;
 		} catch (err) {
 			// Ignore preload errors
 		}
 	}
 
-	const observable = client.watchQuery<TData>(queryOptions);
+	const observable = client.watchQuery(queryOptions);
+	
 	const store = observableQueryToReadable(
 		observable,
 		initialValue as Result<TData>


### PR DESCRIPTION
Hi, @timhall!  `readQuery` returns data result. So, when it passed to `observableQueryToReadable` occurs different query result between server and client. Tested this with sapper and it works pretty nice!