### PR TITLE
Export observableToReadable to use subscriptions inside of event handlers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { getClient, setClient } from "./context";
 export { mutation } from "./mutation";
+export { observableToReadable } from "./observable";
 export type { ReadableQuery, ReadableResult, Result } from "./observable";
 export { query } from "./query";
 export { restore } from "./restore";


### PR DESCRIPTION
Export observableToReadable so client.subscribe can be wrapped when called inside an event handler.