### PR TITLE
Un-shadow fundamental Error type

### DIFF
--- a/src/observable.ts
+++ b/src/observable.ts
@@ -11,7 +11,7 @@ export interface Loading {
 	data?: undefined;
 	error?: undefined;
 }
-export interface Error {
+export interface ReadableError {
 	loading: false;
 	data?: undefined;
 	error: ApolloError | Error;
@@ -22,7 +22,7 @@ export interface Data<TData = unknown> {
 	error?: undefined;
 }
 
-export type Result<TData = unknown> = Loading | Error | Data<TData>;
+export type Result<TData = unknown> = Loading | ReadableError | Data<TData>;
 
 // Some methods, e.g. subscription, use Observable<FetchResult>,
 // convert this more raw value to a readable


### PR DESCRIPTION
When ReadableResult is in its error state, the error it provides at runtime can be either an [`ApolloError` (from @apollo/client)](https://github.com/apollographql/apollo-client/blob/29d41eb590157777f8a65554698fcef4d757a691/src/errors/index.ts)
or an [`Error` (the fundamental type)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error).

However, because the ReadableResult's error interface is named `Error`, its error state (accidentally?) defines its provided error in TypeScript as either an `ApolloError` or its own error state (recursively).

<img width="978" alt="Screen Shot 2021-02-17 at 7 51 41 AM" src="https://user-images.githubusercontent.com/77209061/108224133-cf2d0800-70f7-11eb-9f58-ebc6fb1490cf.png">

I believe the simplest solution to this is to rename the error state's interface - I've proposed `ReadableError` here, but I defer to your judgement on what name is best.

Thank you!