### PR TITLE
Add notice about Vite error

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,3 +225,14 @@ Get an Apollo client from the current component's context.
   const client = getClient();
 </script>
 ```
+
+Caveat: when using Vite as your bundler and encounter the error `Function called outside component initialization`, you must add `svelte-apollo` to Vite's `optimizeDeps.exclude` configuration property:
+
+```
+{
+  optimizeDeps: {
+    exclude: ["svelte-apollo"],
+  }
+  // other properties
+}
+```


### PR DESCRIPTION
The error "Function called outside component initialization" is encountered by many, and its cause always is obscure to the developer. This issue is commonly raised on Stackoverflow, Github, and other platforms, with no success at receiving a concrete solution.

This was also recently mentioned in issue #61, but no initiative was taken.