### PR TITLE
chore: update types to account for changes in TypeScript 4.8

### DIFF
--- a/.changeset/modern-timers-itch.md
+++ b/.changeset/modern-timers-itch.md
@@ -1,0 +1,5 @@
+---
+"svelte-apollo": patch
+---
+
+`TVariable` generics now `extend OperationVariables` to accommodate an upstream type change in @apollo/client@3.7.6.

--- a/packages/svelte-apollo/package.json
+++ b/packages/svelte-apollo/package.json
@@ -30,7 +30,7 @@
 		"svelte": "^3"
 	},
 	"devDependencies": {
-		"@apollo/client": "^3.5.9",
+		"@apollo/client": "^3.7.7",
 		"@jest/globals": "^27.5.1",
 		"@rollup/plugin-typescript": "^6.1.0",
 		"graphql": "^15.8.0",
@@ -42,7 +42,7 @@
 		"svelte": "^3.46.4",
 		"ts-jest": "^27.1.3",
 		"tslib": "^2.3.1",
-		"typescript": "^4.5.5"
+		"typescript": "^4.9.5"
 	},
 	"files": [
 		"dist"

--- a/packages/svelte-apollo/src/__tests__/observable.test.ts
+++ b/packages/svelte-apollo/src/__tests__/observable.test.ts
@@ -1,4 +1,4 @@
-import { ApolloError, Observable } from "@apollo/client/core";
+import { ApolloError, Observable, FetchResult } from "@apollo/client/core";
 import { GraphQLError } from "graphql";
 import { DataState, observableToReadable } from "../observable";
 import { read } from "../__fixtures__/read";
@@ -16,7 +16,7 @@ test("should return ApolloError for errors", async () => {
 
 test("should return observable error", async () => {
 	const readable = observableToReadable(
-		new Observable(() => {
+		new Observable<FetchResult<unknown>>(() => {
 			throw new Error("Internal Error");
 		})
 	);

--- a/packages/svelte-apollo/src/mutation.ts
+++ b/packages/svelte-apollo/src/mutation.ts
@@ -1,4 +1,8 @@
-import type { FetchResult, MutationOptions } from "@apollo/client/core";
+import type {
+	FetchResult,
+	MutationOptions,
+	OperationVariables,
+} from "@apollo/client/core";
 import type { DocumentNode } from "graphql";
 import { getClient } from "./context";
 
@@ -11,7 +15,10 @@ export type Mutate<T = unknown, TVariables = unknown> = (
 	options: MutateOptions<T, TVariables>
 ) => Promise<FetchResult<T>>;
 
-export function mutation<T = unknown, TVariables = unknown>(
+export function mutation<
+	T = unknown,
+	TVariables extends OperationVariables = OperationVariables
+>(
 	mutation: DocumentNode,
 	initialOptions: MutateOptions<T, TVariables> = {}
 ): Mutate<T, TVariables> {

--- a/packages/svelte-apollo/src/observable.ts
+++ b/packages/svelte-apollo/src/observable.ts
@@ -1,4 +1,4 @@
-import { ApolloError } from "@apollo/client/core";
+import { ApolloError, OperationVariables } from "@apollo/client/core";
 import type {
 	FetchResult,
 	Observable,
@@ -120,7 +120,7 @@ export type ReadableQuery<TData> = ReadableResult<TData> &
 
 export function observableQueryToReadable<
 	TData = unknown,
-	TVariables = unknown
+	TVariables extends OperationVariables = OperationVariables
 >(
 	query: ObservableQuery<TData, TVariables>,
 	initialValue?: Result<TData>

--- a/packages/svelte-apollo/src/query.ts
+++ b/packages/svelte-apollo/src/query.ts
@@ -1,11 +1,17 @@
-import type { WatchQueryOptions } from "@apollo/client/core";
+import type {
+	WatchQueryOptions,
+	OperationVariables,
+} from "@apollo/client/core";
 import type { DocumentNode } from "graphql";
 import { getClient } from "./context";
 import { DataState, observableQueryToReadable } from "./observable";
 import type { ReadableQuery } from "./observable";
 import { restoring } from "./restore";
 
-export function query<TData = unknown, TVariables = unknown>(
+export function query<
+	TData = unknown,
+	TVariables extends OperationVariables = OperationVariables
+>(
 	query: DocumentNode,
 	options: Omit<WatchQueryOptions<TVariables, TData>, "query"> = {}
 ): ReadableQuery<TData> {

--- a/packages/svelte-apollo/src/subscribe.ts
+++ b/packages/svelte-apollo/src/subscribe.ts
@@ -1,10 +1,13 @@
-import type { SubscriptionOptions } from "@apollo/client/core";
+import type { SubscriptionOptions, OperationVariables } from "@apollo/client/core";
 import type { DocumentNode } from "graphql";
 import { getClient } from "./context";
 import { observableToReadable } from "./observable";
 import type { ReadableResult } from "./observable";
 
-export function subscribe<TData = unknown, TVariables = unknown>(
+export function subscribe<
+	TData = unknown,
+	TVariables extends OperationVariables = OperationVariables
+>(
 	query: DocumentNode,
 	options: Omit<SubscriptionOptions<TVariables>, "query"> = {}
 ): ReadableResult<TData> {


### PR DESCRIPTION
In @apollo/client [v3.7.6](https://github.com/apollographql/apollo-client/blob/main/CHANGELOG.md#376), we made a TS upgrade that prompted us to [propagate constraints on generic types](https://devblogs.microsoft.com/typescript/announcing-typescript-4-8/#unconstrained-generics-no-longer-assignable-to):

> Technically this makes some types stricter as attempting to pass `null|undefined` into certain functions is now disallowed by TypeScript, but these were never expected runtime values in the first place.

I was taking a look at how the stricter types impacted community projects and thought I'd open this PR. The `TVariables` generics are stricter, but this should hopefully not result in breaking changes for users since it more accurately reflects the types we expect at runtime.